### PR TITLE
날짜 오류 수정

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1302,7 +1302,7 @@
      "title": "우분투한국커뮤니티 * 한국애저사용자그룹 9월 연합세미나",
      "url": "https://ubuntu-kr.github.io/events/2017/08/25/ubuntu-kr-krazure-joint-seminar.html",
      "start": "2017-09-16 14:00:00",
-     "end": "2017-09-10 18:00:00",
+     "end": "2017-09-16 18:00:00",
      "address": "한국마이크로소프트",
      "tags": "ubuntu, linux, windows, azure, desktop, cloud"
    }


### PR DESCRIPTION
우분투한국커뮤니티 * 한국Azure사용자그룹 9월 연합세미나 행사 정보중 날짜에 오류가 있어 수정하였습니다.