### PR TITLE
이벤트 추가 : GDG Korea Campus 1주년 Meet-up

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1594,7 +1594,15 @@
      "end": "2018-01-13 18:00:00",
      "address": "한국마이크로소프트(광화문)",
      "tags": "devops"
-    }
- 
+    },
+    {
+      "id": 178,
+      "title": "GDG Korea Campus 1주년 Meet-up",
+      "url": "http://lemonlab.co.kr/gdg/1year/",
+      "start": "2017-11-03 19:30:00",
+      "end": "2017-11-03 23:00:00",
+      "address": "D.CAMP 6층 메인홀",
+      "tags": "GDG, Campus"
+     },
   ]
 }


### PR DESCRIPTION
Add 1 Event
2017/11/3 GDG Korea Campus 1주년 Meet-up 


PS : PR방식 외 웹페이지에서 바로 추가 요청 후 관리자님이 Accept만 하면 반영되는 인터페이스가 있으면 좋을 것같습니다.. ㅎㅎ